### PR TITLE
Canvas paging

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -1,11 +1,13 @@
 'use strict';
 
+var _ = require('underscore');
 var Promise = require('bluebird');
 var request = Promise.promisify(require('request'));
 var resolve = require('url').resolve;
 var qs = require('qs');
 var merge = require('lodash.merge');
 var isString = require('lodash.isstring');
+var parseLink = require('parse-link-header');
 
 function Canvas(host, options) {
     options = options || {};
@@ -25,7 +27,8 @@ Canvas.prototype._buildApiUrl = function (endpoint) {
     return resolve(this.host,  '/api/' + this.apiVersion + endpoint);
 };
 
-Canvas.prototype._http = function (options) {
+Canvas.prototype._http = function (options, prevBody) {
+    var that = this;
     options.headers = {
         Authorization: 'Bearer ' + this.accessToken
     };
@@ -48,8 +51,19 @@ Canvas.prototype._http = function (options) {
                 err.code = response.statusCode;
                 throw err;
             }
-
-            return body;
+            if(response.headers.link){
+                var nextLink = parseLink(response.headers.link);
+                if (nextLink.next) {
+                    nextLink = nextLink.next.url.split('?');
+                    var nextOptions = {
+                        method: options.method,
+                        url: nextLink[0],
+                        qs: qs.parse(nextLink[1])
+                    };
+                    return that._http(nextOptions, _.union(prevBody, body));
+                }
+            }
+            return _.union(prevBody, body);
         });
 };
 

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -35,9 +35,22 @@ Canvas.prototype._http = function (options, prevBody) {
 
     options.json = true;
 
-    return request(options)
-        .spread(function (response, body) {
+    // If we've exhausted half the rate limit start delaying our requests so we don't run out the rest
+    var throttle = 0;
+    if(this.rateLimitRemaining && this.rateLimitRemaining < this.rateLimitMax / 2) {
+       throttle = getRandomInt(50, 100);
+    }
+
+    return Promise.delay(throttle).then(function() {
+      return request(options).spread(function (response, body) {
             if ((response.statusCode !== 200) && (response.statusCode !== 201)) {
+                // Check for throttling and retry after a delay
+                if (response.statusCode === 403 && /Rate Limit Exceeded/.test(response.body)) {
+                    // Use a random delay so that we don't retry a ton of requests at the same time and exhaust the limit again
+                    return Promise.delay(getRandomInt(200, 500)).then(function() {
+                        return that._http(options, prevBody);
+                     });
+                }
                 var err = new Error();
                 try {
                     err.message = body.errors.map(function (err) {
@@ -51,6 +64,10 @@ Canvas.prototype._http = function (options, prevBody) {
                 err.code = response.statusCode;
                 throw err;
             }
+            if (! that.rateLimitMax) {
+                that.rateLimitMax = response.headers['x-rate-limit-remaining'];
+            }
+            that.rateLimitRemaining = response.headers['x-rate-limit-remaining'];
             if(response.headers.link){
                 var nextLink = parseLink(response.headers.link);
                 if (nextLink.next) {
@@ -63,8 +80,12 @@ Canvas.prototype._http = function (options, prevBody) {
                     return that._http(nextOptions, _.union(prevBody, body));
                 }
             }
-            return _.union(prevBody, body);
+            if(prevBody){
+                return _.union(prevBody, body);
+            }
+            return body;
         });
+    });
 };
 
 Canvas.prototype._querify = function (query) {
@@ -120,5 +141,9 @@ Canvas.prototype.put = function (endpoint, querystring, form, qsStringifyOptions
 
     return this._http(options);
 };
+
+function getRandomInt(min, max) {
+      return Math.floor(Math.random() * (max - min)) + min;
+}
 
 module.exports = Canvas;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "bluebird": "^2.9.25",
     "lodash.isstring": "^3.0.1",
     "lodash.merge": "^3.2.1",
+    "parse-link-header": "^0.4.1",
     "qs": "^2.4.1",
-    "request": "^2.55.1"
+    "request": "^2.55.1",
+    "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Canvas pages result sets (larger than 10 by default): https://canvas.instructure.com/doc/api/file.pagination.html

Am I missing something, or does this library not support paged responses?

I have a branch in progress that will detect the Link header and recursively request more pages until it has them all, but it's currently running into Canvas' throttling:
https://canvas.instructure.com/doc/api/file.throttling.html
