### PR TITLE
feature - add userAgent option for custom User-Agent header

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -15,6 +15,7 @@ function Canvas(host, options) {
     this.query = options.query || {};
     this.host = host;
     this.qsStringifyOptions = { arrayFormat: 'brackets' };
+    this.userAgent = options.userAgent || options['user-agent'] || null;
 }
 
 function random(low, high) {
@@ -28,7 +29,8 @@ Canvas.prototype._buildApiUrl = function (endpoint) {
 Canvas.prototype._http = function (options, prevBody) {
     options.headers = {
         Authorization: 'Bearer ' + this.accessToken,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...(this.userAgent ? { 'User-Agent': this.userAgent } : {}),
     };
 
     // If we've exhausted half the rate limit start delaying our requests so we don't run out the rest


### PR DESCRIPTION
PR implements an additional optional parameter called 'userAgent' in Canvas constructor, allowing users to set a custom 'User-Agent' header in all Canvas api requests. 